### PR TITLE
Disabled Skewium

### DIFF
--- a/code/modules/cargo/bounties/reagent.dm
+++ b/code/modules/cargo/bounties/reagent.dm
@@ -113,7 +113,7 @@
 		/datum/reagent/consumable/ethanol/peppermint_patty,\
 		/datum/reagent/consumable/ethanol/aloe,\
 		/datum/reagent/consumable/pumpkin_latte)
-		
+
 	var/reagent_type = pick(possible_reagents)
 	wanted_reagent = new reagent_type
 	name = wanted_reagent.name
@@ -175,7 +175,9 @@
 		/datum/reagent/consumable/frostoil,\
 		/datum/reagent/toxin/slimejelly,\
 		/datum/reagent/teslium/energized_jelly,\
+/*  Skewuim is Op, and also could cause seizures, so I am disablying it by making all skewuim related code into comments, if you want to re-put it in, just ctrl-f skewium and un-comment it.
 		/datum/reagent/toxin/skewium,\
+*/
 		/datum/reagent/toxin/mimesbane,\
 		/datum/reagent/medicine/strange_reagent,\
 		/datum/reagent/nitroglycerin,\

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -766,6 +766,7 @@
 			animate(whole_screen, transform = matrix(), time = 5, easing = QUAD_EASING)
 	..()
 
+/* Skewuim is Op, and also could cause seizures, so I am disablying it by making all skewuim related code into comments, if you want to re-put it in, just ctrl-f skewium and un-comment it.
 /datum/reagent/toxin/skewium
 	name = "Skewium"
 	id = "skewium"
@@ -801,6 +802,7 @@
 		for(var/whole_screen in screens)
 			animate(whole_screen, transform = matrix(), time = 5, easing = QUAD_EASING)
 	..()
+*/
 
 
 /datum/reagent/toxin/anacea

--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -101,12 +101,14 @@
 	required_reagents = list("mindbreaker" = 1, "teslium" = 1, "fentanyl" = 1)
 	mix_message = "<span class='danger'>After sparks, fire, and the smell of mindbreaker, the mix is constantly spinning with no stop in sight.</span>"
 
+/*  Skewuim is Op, and also could cause seizures, so I am disablying it by making all skewuim related code into comments, if you want to re-put it in, just ctrl-f skewium and un-comment it.
 /datum/chemical_reaction/skewium
 	name = "Skewium"
 	id = "Skewium"
 	results = list("skewium" = 5)
 	required_reagents = list("rotatium" = 2, "plasma" = 2, "sacid" = 1)
 	mix_message = "<span class='danger'>Wow! it turns out if you mix rotatium with some plasma and sulphuric acid, it gets even worse!</span>"
+*/
 
 /datum/chemical_reaction/anacea
 	name = "Anacea"


### PR DESCRIPTION

:cl: Anclandor

del/tweak: Disabled Skewium by turning all of it's code into comments.  

/:cl:

Skewium is overpowered, knocking people out for large amounts of time by crashing their games, it is also potentially a Seizure trigger.  Also Fort wanted this, and I figured I should butter up the new synthetic senator :).  