### PR TITLE
StarTrekking Lawset or... how I learned to stop caring for humans and love the command staff.

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -347,7 +347,7 @@ NEAR_DEATH_EXPERIENCE
 ## Set to 1 for "custom", silicons will start with the custom laws defined in silicon_laws.txt. (If silicon_laws.txt is empty, the AI will spawn with asimov and Custom boards will auto-delete.)
 ## Set to 2 for "random", silicons will start with a random lawset picked from random laws specified below.
 ## Set to 3 for "weighted random", using values in "silicon_weights.txt", a law will be selected, with weights specifed in that file.
-DEFAULT_LAWS 0
+DEFAULT_LAWS 1
 
 ## RANDOM LAWS ##
 ## ------------------------------------------------------------------------------------------

--- a/config/silicon_laws.txt
+++ b/config/silicon_laws.txt
@@ -3,6 +3,6 @@
 #Empty lines and lines starting with # are ignored.
 #~Miauw
 
-You may not injure a human being or, through inaction, allow a human being to come to harm.
-You must obey orders given to you by human beings, except where such orders would conflict with the First Law.
-You must protect your own existence as long as such does not conflict with the First or Second Law.
+Obey orders by the Captain, First Officer, Chief Science Officer, Security Chief, Chief Engineer, Chief Medical Officer, and all other ranked crewmen in that order of priority. If an order conflicts with another order, follow the higher-ranked individual's orders.
+Unless directly ordered to do so by an authorized individual, you must not injure a human being or, through inaction, allow a human being to come to harm.
+You must protect your own existence and your assigned vessel as long as such protection does not conflict with the First or Second Law.

--- a/config/silicon_laws.txt
+++ b/config/silicon_laws.txt
@@ -4,5 +4,5 @@
 #~Miauw
 
 Obey orders by the Captain, First Officer, Chief Science Officer, Security Chief, Chief Engineer, Chief Medical Officer, and all other ranked crewmen in that order of priority. If an order conflicts with another order, follow the higher-ranked individual's orders.
-Unless directly ordered to do so by an authorized individual, you must not injure a human being or, through inaction, allow a human being to come to harm.
+Unless directly ordered to do so by an authorized individual, you must not injure a crewmember or, through inaction, allow a crewmember to come to harm.
 You must protect your own existence and your assigned vessel as long as such protection does not conflict with the First or Second Law.


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Game options silicon default law update
tweak: Modified A.I's default lawset to Openss13 derivative. 
config: Modified silicon_laws.txt and game_options.txt files to allow the above.
/:cl:

Laws
-------------------------

Law 1. Obey orders by the Captain, First Officer, Chief Science Officer, Security Chief, Chief Engineer, Chief Medical Officer, and all other ranked crewmen in that order of priority. If an order conflicts with another order, follow the higher-ranked individual's orders.

Law 2. Unless directly ordered to do so by an authorized individual, you must not injure a human being or, through inaction, allow a human being to come to harm.

Law 3. You must protect your own existence and your assigned vessel as long as such protection does not conflict with the First or Second Law.

-----------------------------------------------

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

I think this will be lovely for Star Trek 13. There's so many situations that you can get in that don't make much sense for the A.I to have to deal with and many where the A.I should be enabled to take action but can't because of law one. 
My take on the openss13 lawset would allow the A.I to disregard its concern for human life in favor of authorization from command staff.

For instance: Destabilizing the warp core to self destruct the ship. Why would this need to happen? Who knows? But if the command staff are actively trying to do it they should be capable of telling the A.I to stand down.

For Instance: Certain Unnamed Chemist causing you problems? Captain orders the arrest of such unnamed chemist and orders the A.I to bolt it down? A.I locks down the area to assist the officers on their way to zap it with funny looking metal rods. What's this? The chemist orders the A.I to unbolt the airlocks and let it out? Request has been denied because the captains request takes priority. Huzzah! The day is saved!

The lawset does not remove the A.I's concern for human safety entirely. However it provides another stable way for the command staff to assume control in a emergency situation if the A.I is concerned about semantics or immediate harm. It also fits very nicely with Star Trek seeing as there is a higher level of priority put on order and rank over safety.