### PR TITLE
Vendor tng uniforms

### DIFF
--- a/code/modules/vending/clothesmate.dm
+++ b/code/modules/vending/clothesmate.dm
@@ -96,6 +96,9 @@
 		            /obj/item/clothing/shoes/sandal = 2,
 		            /obj/item/clothing/suit/jacket/miljacket = 1,
 		            /obj/item/clothing/suit/apron/purple_bartender = 2,
+					/obj/item/clothing/under/trek/cadet = 3,
+		            /obj/item/clothing/under/trek/ensign/tng = 3,
+		            /obj/item/clothing/accessory/ds9_jacket = 2,
 		            /obj/item/clothing/under/rank/bartender/purple = 2)
 	contraband = list(/obj/item/clothing/under/syndicate/tacticool = 1,
 		              /obj/item/clothing/mask/balaclava = 1,

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -24,6 +24,8 @@
 					/obj/item/clothing/under/rank/security/skirt = 3,
 					/obj/item/clothing/under/rank/security/grey = 3,
 					/obj/item/clothing/under/pants/khaki = 3,
+					/obj/item/clothing/under/trek/engsec/ds9 = 3,
+					/obj/item/clothing/accessory/ds9_jacket/engsec = 3,
 					/obj/item/clothing/under/rank/security/blueshirt = 3)
 	premium = list(/obj/item/clothing/under/rank/security/navyblue = 3,
 					/obj/item/clothing/suit/security/officer = 3,
@@ -56,6 +58,8 @@
 					/obj/item/clothing/shoes/sneakers/white = 4,
 					/obj/item/clothing/head/soft/emt = 4,
 					/obj/item/clothing/suit/apron/surgical = 4,
+					/obj/item/clothing/under/trek/medsci/ds9 = 4,
+					/obj/item/clothing/accessory/ds9_jacket/medsci = 3,
 					/obj/item/clothing/mask/surgical = 4)
 	refill_canister = /obj/item/vending_refill/wardrobe/medi_wardrobe
 	payment_department = ACCOUNT_MED
@@ -77,6 +81,8 @@
 					/obj/item/clothing/under/rank/engineer/hazard = 3,
 					/obj/item/clothing/suit/hazardvest = 3,
 					/obj/item/clothing/shoes/workboots = 3,
+					/obj/item/clothing/under/trek/engsec/ds9 = 3,
+					/obj/item/clothing/accessory/ds9_jacket/engsec = 3,
 					/obj/item/clothing/head/hardhat = 3)
 	refill_canister = /obj/item/vending_refill/wardrobe/engi_wardrobe
 	payment_department = ACCOUNT_ENG
@@ -112,6 +118,7 @@
 					/obj/item/clothing/shoes/sneakers/black = 3,
 					/obj/item/clothing/gloves/fingerless = 3,
 					/obj/item/clothing/head/soft = 3,
+					/obj/item/clothing/under/trek/shuttle = 3,
 					/obj/item/radio/headset/headset_cargo = 3)
 	premium = list(/obj/item/clothing/under/rank/miner = 3)
 	refill_canister = /obj/item/vending_refill/wardrobe/cargo_wardrobe
@@ -151,6 +158,8 @@
 					/obj/item/clothing/suit/toggle/labcoat/science = 3,
 					/obj/item/clothing/shoes/sneakers/white = 3,
 					/obj/item/radio/headset/headset_sci = 3,
+					/obj/item/clothing/under/trek/medsci/ds9 = 3,
+					/obj/item/clothing/accessory/ds9_jacket/medsci = 2,
 					/obj/item/clothing/mask/gas = 3)
 	refill_canister = /obj/item/vending_refill/wardrobe/science_wardrobe
 	payment_department = ACCOUNT_SCI


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Vendor Clothing Update The Next Generation
Added The Next Generation clothing to the following vendors.

Secdrobe
--
TNG EngSec uniform
Deepspace9 EngSec jacket

Medidrobe
--
TNG MedSci uniform
Deepspace9 MedSci jacket

Engidrobe
--
TNG EngSec uniform
Deepspace 9 EngSec jacket

Cargodrobe
--
Shuttle Pilot uniform

Scidrobe
--
TNG MedSci uniform
Deepspace9 MedSci jacket

ClothesMate
--
TNG Cadet uniform
TNG Ensign uniform
Deepspace9 non-departmental jacket
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

It was rather bothersome that these clothing options, despite being departmental defaults, were not included in ship clothes vending machines. I've fixed that. Enjoy your jackets, please.. this took me a hour... they don't let me play until I meet a quota...


Ignore the commit regarding the silicon default law updates, that was a accidental push and shouldn't affect the master repository as it's already been added.
