### PR TITLE
Phaser Stun Cost Decrease

### DIFF
--- a/DS13/code/game/objects/weapons.dm
+++ b/DS13/code/game/objects/weapons.dm
@@ -47,7 +47,6 @@
 	icon_state = "solar"
 
 /obj/item/ammo_casing/energy/disabler/phaserstun
-	e_cost = 60
 	fire_sound = 'DS13/sound/effects/weapons/phaser.ogg'
 	select_name = "stun"
 	projectile_type = /obj/item/projectile/beam/disabler/phaser

--- a/DS13/code/game/objects/weapons.dm
+++ b/DS13/code/game/objects/weapons.dm
@@ -47,7 +47,7 @@
 	icon_state = "solar"
 
 /obj/item/ammo_casing/energy/disabler/phaserstun
-	e_cost = 160
+	e_cost = 60
 	fire_sound = 'DS13/sound/effects/weapons/phaser.ogg'
 	select_name = "stun"
 	projectile_type = /obj/item/projectile/beam/disabler/phaser


### PR DESCRIPTION

:cl: Anclandor
balance: Made Phaser stun beams cost the same as disabler beams (50e)
/:cl:

Now that phaser stun beams don't insta-stun, phasers run out of energy impractically fast.