### PR TITLE
Updates the "Space Station 13!" text with "Star Trek 13!" title at the round start.

### DIFF
--- a/config/motd.txt
+++ b/config/motd.txt
@@ -1,5 +1,5 @@
 <!-- Most valid html will work in here, excluding images. -->
 
-<h1>Welcome to Space Station 13!</h1>
+<h1>Welcome to Star Trek 13!</h1>
 
 <i>This server is running a /tg/station 13 Git build.</i>


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: optional name here

tweak: tweaked the title/text at the roundstart to say "Star Trek 13" and not "Space Station 13"

config: title/text at the roundstart to say "Star Trek 13" and not "Space Station 13". this is in Config > motd.txt 


/:cl:

[why]: #  It is Star Trek 13 and the title at the roundstart should reflect that? from what I have been told this is really old tg code so I suppose that could also be the reason why it said "ss13".

Note: The bottom "told you" part is not included.

![JZncG7T](https://user-images.githubusercontent.com/66401072/109302556-7c1b2980-784a-11eb-91fa-673caa2d7852.png)

