### PR TITLE
Gives Bridge Officers access to the Transporter.

### DIFF
--- a/DS13/code/modules/jobs/job_types/bridge.dm
+++ b/DS13/code/modules/jobs/job_types/bridge.dm
@@ -11,8 +11,8 @@ Bridge crew
 	spawn_positions = 3
 	supervisors = "the first officer"
 	selection_color = "#ccccff"
-	access = list(ACCESS_HEADS, ACCESS_MAINT_TUNNELS)
-	minimal_access = list(ACCESS_HEADS, ACCESS_MAINT_TUNNELS)
+	access = list(ACCESS_HEADS, ACCESS_MAINT_TUNNELS, ACCESS_SEC_DOORS, ACCESS_ENGINE_EQUIP)
+	minimal_access = list(ACCESS_HEADS, ACCESS_MAINT_TUNNELS, ACCESS_SEC_DOORS, ACCESS_ENGINE_EQUIP)
 	outfit = /datum/outfit/job/bridge
 	paycheck = PAYCHECK_COMMAND
 	paycheck_department = ACCOUNT_SEC


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Bridge Officers Get Transporter Access
add: Security general access to Bridge Officer I.D's
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
Why? Why wasn't this a thing already? There has been so many occasions when the only one present to attend to the transporter is a bridge officer, or a commanding officer beams over and entirely forgets their bridge staff only have bridge maintenance, and bridge access. They're bridge ensigns, but you should be able to man the transporter if you're qualified to operate on the bridge. The security access isn't really for the department, it's just the necessary I.D code to operate the transporter.