### PR TITLE
Walk/Run speed changes for more roleplay oriented gameplay.

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -32,8 +32,8 @@ EMOJIS
 ## To speed things up make the number negative, to slow things down, make the number positive.
 
 ## These modify the run/walk speed of all mobs before the mob-specific modifiers are applied.
-RUN_DELAY 1
-WALK_DELAY 4
+RUN_DELAY 1.5
+WALK_DELAY 3
 
 ## The variables below affect the movement of specific mob types. THIS AFFECTS ALL SUBTYPES OF THE TYPE YOU CHOOSE!
 ## Entries completely override all subtypes. Later entries have precedence over earlier entries.


### PR DESCRIPTION
[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl: Run/Walk Speed changes
Tweak: Modifies run speed from 1 to 1.5 meaning slower(see line 32 of game options if you don't get what I mean.)
Tweak: Modifies walkspeed from 4 to 3, meaning faster. 
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
These are the default speeds from Whitesands and Beestation Hornet. Seeing as this code that Star Trek 13 is based on was using old TG station, it might be wise to lower the runspeed(standard most use), so we finally realize not every crewmember is on bath salts 24/7. If need be this may need to be readjusted.